### PR TITLE
Enable support for IRSA in AWS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,6 +130,11 @@ For S3, you have to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as envir
 or `aws.accessKeyId` and `aws.secretKey` as system properties or you put them into ~/.aws/credentials.
 S3 backup module is receptive to `AWS_REGION` as well as `AWS_ENDPOINT` environment variables.
 
+As of release `1.1.4` the aws-sdk-java library is capable of using
+https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[IAM Roles for Service Accounts].
+IRSA allows you to grant an AWS IAM Role to a Kubernetes Service Account without mounting secrets,
+passing environment variables or using node profiles.
+
 ### Azure
 
 For Azure, you need to set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.instaclustr</groupId>
   <artifactId>instaclustr-backup-restore</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
 
   <name>instaclustr-backup-restore</name>
   <description>Backup and restoration tooling for Cassandra</description>
@@ -15,7 +15,7 @@
     <instaclustr.commons.version>1.1.0</instaclustr.commons.version>
     <azure-storage.version>8.6.0</azure-storage.version>
     <google-cloud-storage.version>1.84.0</google-cloud-storage.version>
-    <aws-java-sdk.version>1.11.614</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.739</aws-java-sdk.version>
 
     <cassandra.driver.version>4.4.0</cassandra.driver.version>
 


### PR DESCRIPTION
This commit adds support for IAM Roles with Service Accounts in AWS.
It requires a [minimum SDK version][0] of `1.11.704` to be aware of this
capability. The library still supports all other means of authentication
with AWS IAM.

We at 11FS Foundry would like to be able to make use of the IRSA feature so we do not have to rely on environment variables or node profiles etc. 

[0]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html